### PR TITLE
Use rgba for caret.line.back - compatibility fix

### DIFF
--- a/Darchon.style.properties
+++ b/Darchon.style.properties
@@ -127,8 +127,7 @@ caret.fore=$(default.color.green)
 caret.width=2
 
 # Caret line
-caret.line.back=#FFFFFF
-caret.line.back.alpha=20
+caret.line.back=#FFFFFF14
 
 # Highlight current word
 highlight.current.word=1


### PR DESCRIPTION
Broken in SciTE4AHK 3.1.0, this fixes it.